### PR TITLE
Add shared Prisma instance

### DIFF
--- a/src/actions/dbActions.ts
+++ b/src/actions/dbActions.ts
@@ -3,9 +3,7 @@ import { auth } from "@/auth";
 import { InfoLinks, ProfileInformation } from "@/interfaces";
 import { SocialMediaLinks } from "@/interfaces/home/SocialMediaLinks.interface";
 import { isValidOrRelativeUrl } from "@/utils";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/lib/prisma";
 
 export const SavePage = async (
   pageName: string,

--- a/src/app/(admin)/page.tsx
+++ b/src/app/(admin)/page.tsx
@@ -2,7 +2,7 @@ import { auth } from "@/auth";
 import { Title } from "@/components";
 import { CardLinks } from "@/components/home/CardLinks";
 import { CardLink } from "@/interfaces";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 
 const cards: CardLink[] = [
@@ -24,7 +24,6 @@ const cards: CardLink[] = [
   },
 ];
 
-const prisma = new PrismaClient();
 
 export default async function HomePage() {
   const session = await auth();

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
## Summary
- provide a singleton `PrismaClient` in `src/lib/prisma.ts`
- use shared prisma client in `SavePage` action
- use shared prisma client on admin page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f44b265788331b1b83366bc3c3f39