### PR TITLE
Fix TopBar padding class

### DIFF
--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -13,7 +13,7 @@ export const TopBar = () => {
     RigthContent = <DefaultActions />;
   }
   return (
-    <div className="flex flex-col xl:flex-row justify-between items-center py-2 px-2 xl:py-4 xlpx-28 border-b-[1px] border-gray-400 bg-white">
+    <div className="flex flex-col xl:flex-row justify-between items-center py-2 px-2 xl:py-4 xl:px-28 border-b-[1px] border-gray-400 bg-white">
         {RigthContent}
     </div>
   );


### PR DESCRIPTION
## Summary
- correct the responsive padding class in `TopBar`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f44b0b4648331bbf36c78c1cf2e84