### PR TITLE
Remove unused demo cards

### DIFF
--- a/src/app/(admin)/page.tsx
+++ b/src/app/(admin)/page.tsx
@@ -1,28 +1,9 @@
 import { auth } from "@/auth";
 import { Title } from "@/components";
 import { CardLinks } from "@/components/home/CardLinks";
-import { CardLink } from "@/interfaces";
 import { PrismaClient } from "@prisma/client";
 import { redirect } from "next/navigation";
 
-const cards: CardLink[] = [
-  {
-    title: "Mi Pagina Personal",
-    identificador: "@juandesigner",
-    descripcion: "Diseñador UI/UX • Creador de contenido",
-    fechaCreacion: new Date(),
-    visitas: 1250,
-    clicks: 340,
-  },
-  {
-    title: "Pagina de Negocios",
-    identificador: "@mybusiness",
-    descripcion: "Consultoría digital y marketing",
-    fechaCreacion: new Date(),
-    visitas: 890,
-    clicks: 210,
-  },
-];
 
 const prisma = new PrismaClient();
 
@@ -46,9 +27,6 @@ export default async function HomePage() {
         description="Manage and edit your link pages"
       />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-7 mt-11">
-        {/* {cards.map((card) => (
-          <CardLinks key={card.identificador} {...card} />
-        ))} */}
         {pages.map((page) => (
           <CardLinks
             key={page.id}


### PR DESCRIPTION
## Summary
- remove unused `cards` variable and its imports in admin page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f44bbb608833180ad1fda959ac28a